### PR TITLE
Update telemetry.hpp

### DIFF
--- a/hw_interface/include/hw_interface/telemetry.hpp
+++ b/hw_interface/include/hw_interface/telemetry.hpp
@@ -21,7 +21,7 @@ class delta_loop_time
 
     public:
         delta_loop_time():
-        lastTimeMetric(ros::Time::now().toNSec()),
+        lastTimeMetric(ros::Time::now()),
         acc(boost::accumulators::tag::rolling_window::window_size = 150)
         {
             metricsEnabled = true;


### PR DESCRIPTION
Fixed bug in telemetry measurements. Current epoch time in Nanoseconds can no longer fit in 32 bits.